### PR TITLE
imgui_memory_editor: Fix clicking in hex area.

### DIFF
--- a/imgui_memory_editor/imgui_memory_editor.h
+++ b/imgui_memory_editor/imgui_memory_editor.h
@@ -172,7 +172,7 @@ struct MemoryEditor
         ImGuiStyle& style = ImGui::GetStyle();
 
         const float footer_height_to_reserve = ImGui::GetStyle().ItemSpacing.y + ImGui::GetFrameHeightWithSpacing(); // 1 separator, 1 input text
-        ImGui::BeginChild("##scrolling", ImVec2(0, -footer_height_to_reserve));
+        ImGui::BeginChild("##scrolling", ImVec2(0, -footer_height_to_reserve), false, ImGuiWindowFlags_NoMove);
         ImDrawList* draw_list = ImGui::GetWindowDrawList();
 
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));


### PR DESCRIPTION
I found it a bit hard to tell exactly (I always find this input-type stuff difficult to debug...) but it looks like clicking on the hex area was being interpreted as an attempt to move the window. The move then deactivated the text box used for user input, which caused the input to be canceled.

Making the child window non-moveable fixes this, but it's possible there's some better way of doing it, e.g., by having the hex view swallow the click or something.

Thanks,

--Tom
