### PR TITLE
Avoid snprintf #define leak.

### DIFF
--- a/imgui_memory_editor/imgui_memory_editor.h
+++ b/imgui_memory_editor/imgui_memory_editor.h
@@ -722,3 +722,6 @@ struct MemoryEditor
 };
 
 #undef _PRISizeT
+#ifdef _MSC_VER
+#undef snprintf
+#endif


### PR DESCRIPTION
The current code leaks a `#define snprintf _snprintf`, which can break user code. This makes sure we contain all of our #defines inside.