### PR TITLE
imgui_memory_editor: Silence compiler warning

### DIFF
--- a/imgui_memory_editor/imgui_memory_editor.h
+++ b/imgui_memory_editor/imgui_memory_editor.h
@@ -721,6 +721,8 @@ struct MemoryEditor
             if (data_format == DataFormat_Hex) { ImSnprintf(out_buf, out_buf_size, "%a", float64); return; }
             break;
         }
+        default:
+            IM_ASSERT(0); // Shouldn't reach
         } // Switch
         IM_ASSERT(0); // Shouldn't reach
     }


### PR DESCRIPTION
```
imgui_memory_editor.h: In member function ‘void MemoryEditor::DisplayPreviewData(size_t, const u8*, size_t, MemoryEditor::DataType, MemoryEditor::DataFormat, char*, size_t) const’:
imgui_memory_editor.h:637:16: warning: enumeration value ‘DataType_COUNT’ not handled in switch [-Wswitch]
         switch (data_type)
```