### PR TITLE
Fixes color value for '.' in ascii display when "Grey out zeroes" set.

### DIFF
--- a/imgui_memory_editor/imgui_memory_editor.h
+++ b/imgui_memory_editor/imgui_memory_editor.h
@@ -415,7 +415,7 @@ struct MemoryEditor
                     }
                     unsigned char c = ReadFn ? ReadFn(mem_data, addr) : mem_data[addr];
                     char display_c = (c < 32 || c >= 128) ? '.' : c;
-                    draw_list->AddText(pos, (display_c == '.') ? color_disabled : color_text, &display_c, &display_c + 1);
+                    draw_list->AddText(pos, (display_c == c) ? color_text : color_disabled, &display_c, &display_c + 1);
                     pos.x += s.GlyphWidth;
                 }
             }


### PR DESCRIPTION
The dot character ('.') is a valid, printable character, but was being inadvertently drawn as greyed out in the memory editor's ascii display. This has been fixed.