### PR TITLE
docs: fix simple typo, caling -> calling

### DIFF
--- a/imgui_memory_editor/imgui_memory_editor.h
+++ b/imgui_memory_editor/imgui_memory_editor.h
@@ -4,7 +4,7 @@
 // Right-click anywhere to access the Options menu!
 // You can adjust the keyboard repeat delay/rate in ImGuiIO.
 // The code assume a mono-space font for simplicity!
-// If you don't use the default font, use ImGui::PushFont()/PopFont() to switch to a mono-space font before caling this.
+// If you don't use the default font, use ImGui::PushFont()/PopFont() to switch to a mono-space font before calling this.
 //
 // Usage:
 //   // Create a window and draw memory editor inside it:


### PR DESCRIPTION
There is a small typo in imgui_memory_editor/imgui_memory_editor.h.

Should read `calling` rather than `caling`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md