### PR TITLE
Removed unused variable

### DIFF
--- a/imgui_memory_editor/imgui_memory_editor.h
+++ b/imgui_memory_editor/imgui_memory_editor.h
@@ -245,7 +245,6 @@ struct MemoryEditor
 
         size_t preview_data_type_size = OptShowDataPreview ? DataTypeGetSize(PreviewDataType) : 0;
 
-        size_t data_editing_addr_backup = DataEditingAddr;
         size_t data_editing_addr_next = (size_t)-1;
         if (DataEditingAddr != (size_t)-1)
         {


### PR DESCRIPTION
Sorry for such a minor thing, but the unused variable breaks pedantic builds.