### PR TITLE
MSYS UCRT64 compatibility

### DIFF
--- a/imgui_memory_editor/imgui_memory_editor.h
+++ b/imgui_memory_editor/imgui_memory_editor.h
@@ -51,7 +51,7 @@
 #include <stdio.h>      // sprintf, scanf
 #include <stdint.h>     // uint8_t, etc.
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(_UCRT)
 #define _PRISizeT   "I"
 #define ImSnprintf  _snprintf
 #else
@@ -59,7 +59,7 @@
 #define ImSnprintf  snprintf
 #endif
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(_UCRT)
 #pragma warning (push)
 #pragma warning (disable: 4996) // warning C4996: 'sprintf': This function or variable may be unsafe.
 #endif


### PR DESCRIPTION
When using the UCRT64 environment of MSYS2 to make a build that links to the UCRT, instead of to the old msvcrt, stdio and `snprintf()` work the way they do in MSVC, and expects the same modifiers. However, `_MSC_VER` is not defined in the UCRT64 headers, and thus the current guard doesn't work. Checking for `_UCRT`, which is defined, fixes this. Without this fix, it is necessary to define `__USE_MINGW_ANSI_STDIO` at compile time so as to switch to its implementation of stdio, or compilation will fail if you set warning flags on (`-Wall`, `-Werror`, etc). One could ofc ignore this warning but that seems like a bad plan...

[Build error log](https://github.com/ocornut/imgui_club/files/9173487/build_62_error_fail_gcc.log)