### PR TITLE
Track hovered address to let users interact with individual bytes

### DIFF
--- a/imgui_memory_editor/imgui_memory_editor.h
+++ b/imgui_memory_editor/imgui_memory_editor.h
@@ -100,6 +100,9 @@ struct MemoryEditor
     bool            (*HighlightFn)(const ImU8* data, size_t off);//= 0      // optional handler to return Highlight property (to support non-contiguous highlighting).
     ImU32           (*BgColorFn)(const ImU8* data, size_t off); // = 0      // optional handler to return custom background color of individual bytes.
 
+    // Public read-only data
+    size_t          HoveredAddr;                                // the address currently being hovered when IsDataHovered() is true.
+
     // [Internal State]
     bool            ContentsWidthChanged;
     size_t          DataPreviewAddr;
@@ -108,7 +111,6 @@ struct MemoryEditor
     char            DataInputBuf[32];
     char            AddrInputBuf[32];
     size_t          GotoAddr;
-    size_t          HoveredAddr;
     size_t          HighlightMin, HighlightMax;
     int             PreviewEndianness;
     ImGuiDataType   PreviewDataType;
@@ -588,6 +590,7 @@ struct MemoryEditor
         ImGui::Text("Bin"); ImGui::SameLine(x); ImGui::TextUnformatted(has_value ? buf : "N/A");
     }
 
+    // If true, the hovered address is in HoveredAddr
     bool IsDataHovered() const
     {
         return HoveredAddr != (size_t)-1;


### PR DESCRIPTION
Adds `HoveredAddr` and `IsDataHovered()` to the memory editor, allowing users to e.g. display tooltips or context menus on individual bytes. Can be used like this:

```cpp
MemoryEditor mem_editor;
std::array<char, 1024> mem;
```
```cpp
mem_editor.DrawWindow("Memory editor", mem.data(), mem.size());
if (mem_editor.IsDataHovered()) {
    ImGui::SetTooltip("addr: %zx", mem_editor.HoveredAddr);
}
```

![image](https://github.com/user-attachments/assets/8c1f9d7b-9256-406e-9322-ae22d9c21b75)
