### PR TITLE
Clamp mouse pos to 0 in mouse_addr calculation

### DIFF
--- a/imgui_memory_editor/imgui_memory_editor.h
+++ b/imgui_memory_editor/imgui_memory_editor.h
@@ -419,7 +419,11 @@ struct MemoryEditor
                     ImGui::SameLine(s.PosAsciiStart);
                     ImVec2 pos = ImGui::GetCursorScreenPos();
                     addr = line_i * Cols;
-                    size_t mouse_addr = addr + (size_t)((ImGui::GetIO().MousePos.x - pos.x) / s.GlyphWidth);
+                    float mposx = ImGui::GetIO().MousePos.x;
+                    float posdiff = mposx - pos.x;
+                    if (posdiff < 0)
+                        posdiff = 0;
+                    size_t mouse_addr = addr + (size_t)(posdiff / s.GlyphWidth);
                     ImGui::PushID(line_i);
                     if (ImGui::InvisibleButton("ascii", ImVec2(s.PosAsciiEnd - s.PosAsciiStart, s.LineHeight)))
                     {


### PR DESCRIPTION
If `ImGui::GetIO().MousePos.x - pos.x` is negative, casting it to size_t causes undefined behavior. Therefore it must be clamped to 0 when performing the mouse_addr calculation.

**Repro**
- compile a program using imgui_memory_editor.h with `-fsanitize=undefined`
- observe an output similar to this:
```
runtime error: -4.25353e+37 is outside the range of representable values of type 'unsigned long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior third_party/imgui_club/imgui_memory_editor.h:422:56
```

There may be better fixes to this (maybe the calculation only fails during the first or last frame?) but I'm not sure so I went for the safest/simplest fix. I tested it quite extensively in [my own app](https://codeberg.org/silverweed/rntviewer) and it seems to work great.