### PR TITLE
Add missing include and remove unused variable

### DIFF
--- a/imgui_multicontext_compositor/imgui_multicontext_compositor.cpp
+++ b/imgui_multicontext_compositor/imgui_multicontext_compositor.cpp
@@ -85,8 +85,6 @@ void ImGuiMultiContextCompositor_PreNewFrameUpdateAll(ImGuiMultiContextComposito
     // - Find out who has an active drag and drop
     for (ImGuiContext* ctx : mcc->ContextsFrontToBack)
     {
-        const bool ctx_is_front = (ctx == mcc->ContextsFrontToBack.front());
-
 #ifdef IMGUI_HAS_DOCK
         // When hovering a secondary viewport, only enable mouse for the context owning it
         // We specifically use 'ctx->IO.MouseHoveredViewport' (current, submitted by backend) and not 'ctx->MouseLastHoveredViewport' (last valid one)

--- a/imgui_multicontext_compositor/imgui_multicontext_compositor.h
+++ b/imgui_multicontext_compositor/imgui_multicontext_compositor.h
@@ -46,6 +46,8 @@
 
 #pragma once
 
+#include "imgui.h"
+
 struct ImGuiMultiContextCompositor
 {
     // List of context + sorted front to back


### PR DESCRIPTION
Super small:
`imgui_multicontext_compositor.h` doesn't compile without `imgui.h` being included first.
`ctx_is_front` in `ImGuiMultiContextCompositor_PreNewFrameUpdateAll` is unused and causes a warning.