### PR TITLE
if memory editor is ReadOnly, don't show input text

### DIFF
--- a/imgui_memory_editor/imgui_memory_editor.h
+++ b/imgui_memory_editor/imgui_memory_editor.h
@@ -48,6 +48,7 @@
 //                       added MouseHoveredAddr public readable field. (#47, #27) [@StrikerX3]
 //                       fixed a data preview crash with 1.91.0 WIP. fixed contiguous highlight color when using data preview.
 //                       *BREAKING* added UserData field passed to all optional function handlers: ReadFn, WriteFn, HighlightFn, BgColorFn. (#50) [@silverweed]
+// - v0.56 (2024/10/31): don't show InputText on selecting bytes if the editor is in ReadOnly mode (#54) [@silverweed]
 //
 // TODO:
 // - This is generally old/crappy code, it should work but isn't very good.. to be rewritten some day.
@@ -382,7 +383,7 @@ struct MemoryEditor
                             flags |= ImGuiInputTextFlags_ReadOnly;
                         flags |= ImGuiInputTextFlags_AlwaysOverwrite; // was ImGuiInputTextFlags_AlwaysInsertMode
                         ImGui::SetNextItemWidth(s.GlyphWidth * 2);
-                        if (ImGui::InputText("##data", DataInputBuf, IM_ARRAYSIZE(DataInputBuf), flags, InputTextUserData::Callback, &input_text_user_data))
+                        if (!ReadOnly && ImGui::InputText("##data", DataInputBuf, IM_ARRAYSIZE(DataInputBuf), flags, InputTextUserData::Callback, &input_text_user_data))
                             data_write = data_next = true;
                         else if (!DataEditingTakeFocus && !ImGui::IsItemActive())
                             DataEditingAddr = data_editing_addr_next = (size_t)-1;


### PR DESCRIPTION
It makes little sense to show an editable InputText if the memory editor is in ReadOnly mode