### PR TITLE
Fix compiler warning when `int32_t` is `long`

### DIFF
--- a/imgui_memory_editor/imgui_memory_editor.h
+++ b/imgui_memory_editor/imgui_memory_editor.h
@@ -58,6 +58,7 @@
 
 #pragma once
 
+#include <inttypes.h>   // PRId32, etc.
 #include <stdio.h>      // sprintf, scanf
 #include <stdint.h>     // uint8_t, etc.
 
@@ -767,16 +768,16 @@ struct MemoryEditor
         {
             int32_t data = 0;
             EndiannessCopy(&data, buf, size);
-            if (data_format == DataFormat_Dec) { ImSnprintf(out_buf, out_buf_size, "%d", data); return; }
-            if (data_format == DataFormat_Hex) { ImSnprintf(out_buf, out_buf_size, "0x%08x", data); return; }
+            if (data_format == DataFormat_Dec) { ImSnprintf(out_buf, out_buf_size, "%" PRId32, data); return; }
+            if (data_format == DataFormat_Hex) { ImSnprintf(out_buf, out_buf_size, "0x%08" PRIx32, data); return; }
             break;
         }
         case ImGuiDataType_U32:
         {
             uint32_t data = 0;
             EndiannessCopy(&data, buf, size);
-            if (data_format == DataFormat_Dec) { ImSnprintf(out_buf, out_buf_size, "%u", data); return; }
-            if (data_format == DataFormat_Hex) { ImSnprintf(out_buf, out_buf_size, "0x%08x", data); return; }
+            if (data_format == DataFormat_Dec) { ImSnprintf(out_buf, out_buf_size, "%" PRIu32, data); return; }
+            if (data_format == DataFormat_Hex) { ImSnprintf(out_buf, out_buf_size, "0x%08" PRIx32, data); return; }
             break;
         }
         case ImGuiDataType_S64:


### PR DESCRIPTION
On some 32-bit targets, the `int32_t` and `uint32_t` types are defined as `long` and `unsigned long`, in which using the format specifiers `%d`, `%u`, or `%x` will produce compiler warnings like following:

    warning: format '%d' expects argument of type 'int', but argument 4
    has type 'int32_t' {aka 'long int'} [-Wformat=]