### PR TITLE
Threaded Rendering: added include guard and inline keywords

### DIFF
--- a/imgui_threaded_rendering/imgui_threaded_rendering.h
+++ b/imgui_threaded_rendering/imgui_threaded_rendering.h
@@ -18,6 +18,7 @@
     // [Render thread] Render later
     ImGui_ImplDX11_RenderDrawData(&snapshot.DrawData);
 */
+#pragma once
 
 // FIXME: Could store an ID in ImDrawList to make this easier for user.
 #include "imgui_internal.h" // ImPool<>, ImHashData
@@ -55,7 +56,7 @@ struct ImDrawDataSnapshot
 // ImDrawDataSnapshot - IMPLEMENTATION
 //-----------------------------------------------------------------------------
 
-void ImDrawDataSnapshot::Clear()
+inline void ImDrawDataSnapshot::Clear()
 {
     for (int n = 0; n < Cache.GetMapSize(); n++)
         if (ImDrawDataSnapshotEntry* entry = Cache.TryGetMapData(n))
@@ -64,7 +65,7 @@ void ImDrawDataSnapshot::Clear()
     DrawData.Clear();
 }
 
-void ImDrawDataSnapshot::SnapUsingSwap(ImDrawData* src, double current_time)
+inline void ImDrawDataSnapshot::SnapUsingSwap(ImDrawData* src, double current_time)
 {
     ImDrawData* dst = &DrawData;
     IM_ASSERT(src != dst && src->Valid);


### PR DESCRIPTION
include guard was added because multiple inclusion bad.
inlines were added so linking translation units which include the header works.