### PR TITLE
minor: Fix snapshot index calculation for ImDrawData

### DIFF
--- a/imgui_threaded_rendering/imgui_threaded_rendering.h
+++ b/imgui_threaded_rendering/imgui_threaded_rendering.h
@@ -12,7 +12,7 @@
 /*
     // Storage. Keep persistent as we reuse buffers across frames.
     ImDrawDataSnapshot g_Snapshots[2];
-    ImDrawDataSnapshot* snapshot = &g_Snapshots[g_FrameIndex % 1];
+    ImDrawDataSnapshot* snapshot = &g_Snapshots[g_FrameIndex % 2];
 
     // [Update thread] Take a snapshot of the ImDrawData
     snapshot->SnapUsingSwap(ImGui::GetDrawData(), ImGui::GetTime());


### PR DESCRIPTION
only zero index will be used, so what was probably meant is  g_FrameIndex % NumSnapshots.

also I've noticed that I get assert inside `ImGui::DestroyContext()`  (`IM_ASSERT(DrawLists.Size == 0);` inside `ImDrawListSharedData` destructor), so probably Clear() should be called. At least this helped in my case.

```
for(ImDrawDataSnapshot& s: g_Snapshots) {
    s.Clear();
}
```